### PR TITLE
Add define for strnlen

### DIFF
--- a/src/dcwproto.c
+++ b/src/dcwproto.c
@@ -28,6 +28,9 @@
 #endif
 #include <dcwproto.h>
 
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
 #include <string.h>
 #include <stdio.h>
 


### PR DESCRIPTION
strnlen was introduced in POSIX 2008. Under strict conditions, it is not available.